### PR TITLE
Bumping netstandard down from 1.4 to 1.3

### DIFF
--- a/src/CoAPNet.Server/CoAPNet.Server.csproj
+++ b/src/CoAPNet.Server/CoAPNet.Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.4;netstandard2.0;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;netcoreapp2.0</TargetFrameworks>
     <DebugType Condition="$(Configuration)=='AppVeyor'">full</DebugType>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageId>NZSmartie.CoAPNet.Server</PackageId>
@@ -26,7 +26,7 @@
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\CoAPNet.Server.xml</DocumentationFile>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.4'">
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.3'">
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.2" />
   </ItemGroup>
 

--- a/src/CoAPNet.Udp/CoAPNet.Udp.csproj
+++ b/src/CoAPNet.Udp/CoAPNet.Udp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.4;netstandard2.0;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;netcoreapp2.0</TargetFrameworks>
     <PackageId>NZSmartie.CoAPNet.Udp</PackageId>
     <Version>0.3.8</Version>
     <PackageVersion>0.3.8</PackageVersion>
@@ -25,7 +25,7 @@
     <DocumentationFile>bin\$(Configuration)\$TargetFramework)\CoAPNet.Udp.xml</DocumentationFile>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.4'">
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.3'">
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.2" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
   </ItemGroup>

--- a/src/CoAPNet/CoAPNet.csproj
+++ b/src/CoAPNet/CoAPNet.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFrameworks>netstandard1.3</TargetFrameworks>
     <DebugType Condition="$(Configuration)=='AppVeyor'">full</DebugType>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageId>NZSmartie.CoAPNet</PackageId>


### PR DESCRIPTION
Wider compatibility

We use code at work which is only compatible up to netstandard 1.3, so I wanted to see if your code runs well at that level. It seems to, all unit tests pass OK !