### PR TITLE
Added support for dual mode socket (IPv4 and IPv6) at the same time.

### DIFF
--- a/samples/SimpleServer/Program.cs
+++ b/samples/SimpleServer/Program.cs
@@ -23,7 +23,7 @@ namespace CoAPDevices
 
             try
             {
-                myServer.BindTo(new CoapUdpEndPoint(IPAddress.Any, Coap.Port) { JoinMulticast = true });
+                myServer.BindTo(new CoapUdpEndPoint(Coap.Port) { JoinMulticast = true });
 
                 myServer.StartAsync(myHandler, CancellationToken.None).GetAwaiter().GetResult();
 
@@ -61,6 +61,8 @@ namespace CoAPDevices
 
         public override CoapMessage Get(CoapMessage request)
         {
+            Console.WriteLine($"Got request: {request}");
+
             return new CoapMessage
             {
                 Code = CoapMessageCode.Content,

--- a/src/CoAPNet.Udp/CoapUdpEndPoint.cs
+++ b/src/CoAPNet.Udp/CoapUdpEndPoint.cs
@@ -61,7 +61,7 @@ namespace CoAPNet.Udp
         }
 
         public CoapUdpEndPoint(int port = 0, ILogger<CoapUdpEndPoint> logger = null)
-            : this(new IPEndPoint(IPAddress.Any, port), logger)
+            : this(new IPEndPoint(IPAddress.IPv6Any, port), logger)
         { }
 
         public CoapUdpEndPoint(IPAddress address, int port = 0, ILogger<CoapUdpEndPoint> logger = null)
@@ -94,7 +94,9 @@ namespace CoAPNet.Udp
                 throw new InvalidOperationException("Can not bind to remote endpoint");
 
 
-            Client = new UdpClient(_endpoint) { EnableBroadcast = true };
+            Client = new UdpClient(AddressFamily.InterNetworkV6) { EnableBroadcast = true };
+            Client.Client.DualMode = true;
+            Client.Client.Bind(_endpoint);
 
             if (JoinMulticast)
             {


### PR DESCRIPTION
See how to solve it here: http://www.lybecker.com/blog/2018/08/23/supporting-ipv4-and-ipv6-dual-mode-network-with-one-socket/

A solution for issue #14 

It does not include test coverage, as the BCL does not offer any way of iterating open ports. Thought about creating simple integration test. Thoughts?