### PR TITLE
Fix placeholder option logic

### DIFF
--- a/src/CoAPNet/Options/OptionFactory.cs
+++ b/src/CoAPNet/Options/OptionFactory.cs
@@ -127,7 +127,7 @@ namespace CoAPNet.Options
                     throw new CoapOptionException($"Unsupported critical option ({number})", new ArgumentOutOfRangeException(nameof(number)));
 
                 // Return a placeholder option to give the application chance at reading them
-                option = new CoapOption(number, type: OptionType.Opaque);
+                option = new CoapOption(number, type: OptionType.Opaque, maxLength: ushort.MaxValue);
             }
 
             option.Decode(stream, length);


### PR DESCRIPTION
OptionFactory has a placeholder option to give the application chance at reading options, but it doesn't actually work as maxLength defaults to 0. 

I gave placeholder option a maxLength of ushort.MaxValue. I realize it would be even better to be able to configure whether options are allowed at all and to configure maximum length for options. But with this fix it at least has a change of reading options.